### PR TITLE
Actually actually make PRs run forever

### DIFF
--- a/.github/workflows/mq.yml
+++ b/.github/workflows/mq.yml
@@ -17,20 +17,20 @@ jobs:
 
       - name: Check run forever file existence
         id: run_forever
-        uses: technote-space/get-diff-action@v6
+        uses: andstor/file-existence-action@v1
         with:
-          PATTERNS: test/run_forever*.txt
+          files: "test/run_forever*.txt"
 
       - name: Run forever
-        if: steps.run_forever.outputs.diff
+        if: steps.run_forever.outputs.files_exists == 'true'
         run: sleep 180s
 
       - name: Check test failure file exists
         id: fail_test
-        uses: technote-space/get-diff-action@v6
+        uses: andstor/file-existence-action@v1
         with:
           files: "test/fail_test*.txt"
 
       - name: fail
-        if: steps.fail_test.outputs.diff
+        if: steps.fail_test.outputs.files_exists == 'true'
         run: exit 1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,8 @@ jobs:
   pr:
     name: Run Pull Request checks
     runs-on: ubuntu-latest
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
     steps:
       - name: Checkout code
@@ -18,10 +20,10 @@ jobs:
 
       - name: Check run forever file existence
         id: run_forever
-        uses: technote-space/get-diff-action@v6
+        uses: andstor/file-existence-action@v1
         with:
-          PATTERNS: test/run_forever*.txt
+          files: "test/run_forever*.txt"
 
       - name: Run forever
-        if: steps.run_forever.outputs.diff && contains('trunk-merge', github.ref)
+        if: steps.run_forever.outputs.files_exists == 'true' && startsWith(env.BRANCH_NAME, 'trunk-merge')
         run: sleep 180s

--- a/test/change2.txt
+++ b/test/change2.txt
@@ -1,1 +1,0 @@
-change content

--- a/test/change5.txt
+++ b/test/change5.txt
@@ -1,1 +1,0 @@
-change content

--- a/test/run_forever_10492.txt
+++ b/test/run_forever_10492.txt
@@ -1,1 +1,0 @@
-change content

--- a/test/run_forever_53412.txt
+++ b/test/run_forever_53412.txt
@@ -1,1 +1,0 @@
-change content

--- a/test/run_forever_76619.txt
+++ b/test/run_forever_76619.txt
@@ -1,1 +1,0 @@
-change content


### PR DESCRIPTION
OK I now realize that, since the MQ branches aren't PRs, we can't actually use a diff to tell if a file exists oops

Proof - you can see the file `run_forever_12345.txt` is found. The check doesn't run because it isn't a trunk-merge branch

![image](https://user-images.githubusercontent.com/28661308/193069654-cc3c6e36-1785-4e6e-a8e3-9c118a5b8f8f.png)
